### PR TITLE
fix problem with serializer hineritance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.2.3 (unreleased)
 ------------------
 
+- Fix problem with DefaultJSONSummarySerializer hineritance in prenotazioniFolder
+  DefaultJSONSummarySerializer override.
+  [lucabel]
 - Add the plone.restapi>=9.6.0 constaint.
   [folix-01]
 

--- a/src/design/plone/ioprenoto/restapi/serializers/ovverrides/prenotazioniFolder.py
+++ b/src/design/plone/ioprenoto/restapi/serializers/ovverrides/prenotazioniFolder.py
@@ -1,6 +1,11 @@
+from design.plone.contenttypes.restapi.serializers.summary import (
+    DefaultJSONSummarySerializer,
+)
+from design.plone.ioprenoto import PRENOTAZIONI_MANAGE_PERMISSION
+from design.plone.ioprenoto.interfaces import IDesignPloneIoprenotoLayer
 from plone import api
-from plone.restapi.interfaces import ISerializeToJson, ISerializeToJsonSummary
-from plone.restapi.serializer.summary import DefaultJSONSummarySerializer
+from plone.restapi.interfaces import ISerializeToJson
+from plone.restapi.interfaces import ISerializeToJsonSummary
 from redturtle.prenotazioni.content.prenotazioni_folder import IPrenotazioniFolder
 from redturtle.prenotazioni.restapi.serializers.adapters.prenotazioni_folder import (
     PrenotazioniFolderSerializer,
@@ -8,8 +13,6 @@ from redturtle.prenotazioni.restapi.serializers.adapters.prenotazioni_folder imp
 from zope.component import adapter
 from zope.interface import implementer
 
-from design.plone.ioprenoto import PRENOTAZIONI_MANAGE_PERMISSION
-from design.plone.ioprenoto.interfaces import IDesignPloneIoprenotoLayer
 
 # TODO: move to registry
 PRENOTAZIONE_APPUNTAMENTO_ADDRESS = "prenotazione-appuntamenti-uffici"


### PR DESCRIPTION
è emerso questo bug collegando un correlato "stanza prenotazioni" ad un ufficio. la vista dell'ufficio si rompe perchè il serializer di default per gli uffici prenotazioni estende quello originale di plone.restapi e non quello di design.plone.contenttypes.

testato il fix al volo in produzione