### PR TITLE
Onceonly

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.2.10 (unreleased)
 -------------------
 
-- Nothing changed yet.
+- onceonly con iocittadino
+  [mamico]
 
 
 1.2.9 (2025-01-22)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -8,7 +8,3 @@ extends =
 #    test_plone51.cfg
 #    test_plone52.cfg
     test_plone60.cfg
-
-[versions]
-redturtle.prenotazioni = 2.0.0.dev3
-collective.taxonomy = 3.0.1

--- a/src/design/plone/ioprenoto/__init__.py
+++ b/src/design/plone/ioprenoto/__init__.py
@@ -3,7 +3,11 @@
 from redturtle.prenotazioni import config
 from zope.i18nmessageid import MessageFactory
 
+import logging
+
+
 _ = MessageFactory("design.plone.ioprenoto")
+logger = logging.getLogger("design.plone.ioprenoto")
 
 PRENOTAZIONI_MANAGE_PERMISSION = "redturtle.prenotazioni: Manage Prenotazioni"
 

--- a/src/design/plone/ioprenoto/restapi/services/booking/add.py
+++ b/src/design/plone/ioprenoto/restapi/services/booking/add.py
@@ -1,5 +1,3 @@
-# TODO: il codice qui è temporaneo, va spostato in redturtle.prenotazioni
-#       di conseguenza l'implementazione si semplifica
 
 from plone import api
 from redturtle.prenotazioni.interfaces import ISerializeToPrenotazioneSearchableItem
@@ -7,11 +5,31 @@ from redturtle.prenotazioni.restapi.services.booking.add import (
     AddBooking as BaseAddBooking,
 )
 from zope.component import getMultiAdapter
+try:
+    from design.plone.iocittadino.interfaces import IDesignPloneIocittadinoLayer
+    WITH_IOCITTADINO = True
+except ImportError:
+    WITH_IOCITTADINO = False
 
 
 class AddBooking(BaseAddBooking):
     def reply(self):
         result = super().reply()
+
+        # XXX: questa parte riguarda onceonly con design.plone.iocittadino, è la parte
+        #      che rimane comunque qui
+        if WITH_IOCITTADINO and IDesignPloneIocittadinoLayer.providedBy(self.request):
+            # se è configurato iocittadino fare onceonly con i dati di iocittadino
+            if not api.user.is_anonymous():
+                user = api.user.get_current()
+                userstore = queryMultiAdapter(
+                    (self.context, user, self.request), IUserStore
+                )
+                import pdb; pdb.set_trace()
+                userstore.set(data={"data": {}}, onceoonly_fields=["email", "phone"])
+
+        # TODO: il codice qui è temporaneo, va spostato in redturtle.prenotazioni
+        #       di conseguenza l'implementazione si semplifica
         catalog = api.portal.get_tool("portal_catalog")
         uid = result["UID"]
         booking = catalog.unrestrictedSearchResults(UID=uid)[0]._unrestrictedGetObject()
@@ -20,7 +38,7 @@ class AddBooking(BaseAddBooking):
             (booking, self.request), ISerializeToPrenotazioneSearchableItem
         )(fullobjects=True)
 
-        # BBB:
+        # BBB: la response deve riportare tutte le info del CT prenotazione
         response["@type"] = booking.portal_type
         response["id"] = booking.getId()  # response["@id"].split("/")[-1]
         if "booking_id" in response:

--- a/src/design/plone/ioprenoto/restapi/services/booking_schema/get.py
+++ b/src/design/plone/ioprenoto/restapi/services/booking_schema/get.py
@@ -1,9 +1,15 @@
 # -*- coding: utf-8 -*-
+from plone import api
 from redturtle.prenotazioni.restapi.services.booking_schema.get import (
     BookingSchema as BaseService,
 )
+from zope.component import queryMultiAdapter
+
+
 try:
     from design.plone.iocittadino.interfaces import IDesignPloneIocittadinoLayer
+    from design.plone.iocittadino.interfaces import IUserStore
+
     WITH_IOCITTADINO = True
 except ImportError:
     WITH_IOCITTADINO = False
@@ -38,7 +44,7 @@ class BookingSchema(BaseService):
     }
 
     def reply(self):
-        data = super.reply()
+        data = super().reply()
         if WITH_IOCITTADINO and IDesignPloneIocittadinoLayer.providedBy(self.request):
             # se è configurato iocittadino fare onceonly con i dati di iocittadino
             if not api.user.is_anonymous():
@@ -50,7 +56,8 @@ class BookingSchema(BaseService):
                 for field in data["fields"]:
                     if field["name"] in userstore.user_properties:
                         if defaults.get(field["name"]):
-                            fields["value"] = defaults[field["name"]]
-                        field["readonly"] = field["name"] in userstore.strict_user_properties
+                            field["value"] = defaults[field["name"]]
+                        field["readonly"] = (
+                            field["name"] in userstore.strict_user_properties
+                        )
         return data
-

--- a/src/design/plone/ioprenoto/tests/test_booking_info.py
+++ b/src/design/plone/ioprenoto/tests/test_booking_info.py
@@ -201,7 +201,8 @@ class TestBookingInfo(unittest.TestCase):
         )
 
         res = self.api_session.get(
-            self.portal.absolute_url() + "/@bookings?fullobjects=1"
+            self.portal.absolute_url()
+            + "/@bookings?fullobjects=1&from=2000-01-01T00:00:00"
         )
         self.assertEqual(res.status_code, 200)
         self.assertEqual(len(res.json()["items"]), 1)


### PR DESCRIPTION
se il cittadino è autenticato e il sistema ha iocittadino, i dati personali email/telefono vengono consolidati come onceonly (per andare serve 1.2.1 di iocittadino, ma il sistema non si rompe con una versione precedente)